### PR TITLE
Debug threading

### DIFF
--- a/components/cam/src/dynamics/se/dp_coupling.F90
+++ b/components/cam/src/dynamics/se/dp_coupling.F90
@@ -226,7 +226,7 @@ subroutine d_p_coupling(phys_state, phys_tend,  pbuf2d, dyn_out)
    call t_startf('dpcopy')
    if (local_dp_map) then
 
-      !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, ioff, ilyr, m, pbuf_chnk, pbuf_frontgf, pbuf_frontga)
+      !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, ioff, ilyr, m, pbuf_chnk, pbuf_frontgf, pbuf_frontga)
       do lchnk = begchunk, endchunk
 
          ncols = get_ncols_p(lchnk)
@@ -279,7 +279,7 @@ subroutine d_p_coupling(phys_state, phys_tend,  pbuf2d, dyn_out)
       end if
 
       if (iam < par%nprocs) then
-         !$omp parallel do num_threads(horz_num_threads) private (ie, bpter, icol, ilyr, m, ncols, ioff)
+         !!$omp parallel do num_threads(horz_num_threads) private (ie, bpter, icol, ilyr, m, ncols, ioff)
          do ie = 1, nelemd
 
             if (fv_nphys > 0) then
@@ -331,7 +331,7 @@ subroutine d_p_coupling(phys_state, phys_tend,  pbuf2d, dyn_out)
       call transpose_block_to_chunk(tsize, bbuffer, cbuffer)
       call t_stopf  ('block_to_chunk')
 
-      !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, cpter, icol, ilyr, m, pbuf_chnk, pbuf_frontgf, pbuf_frontga, ioff)
+      !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, cpter, icol, ilyr, m, pbuf_chnk, pbuf_frontgf, pbuf_frontga, ioff)
       do lchnk = begchunk, endchunk
          ncols = phys_state(lchnk)%ncol
 
@@ -401,7 +401,7 @@ subroutine d_p_coupling(phys_state, phys_tend,  pbuf2d, dyn_out)
    call derived_phys_dry(phys_state, phys_tend, pbuf2d)
    call t_stopf('derived_phys')
 
-!$omp parallel do private (lchnk, ncols, ilyr, icol)
+!!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, ilyr, icol)
    do lchnk = begchunk, endchunk
       ncols=get_ncols_p(lchnk)
       if (pcols > ncols) then
@@ -473,7 +473,7 @@ subroutine p_d_coupling(phys_state, phys_tend, dyn_in, tl_f, tl_qdp)
    call t_startf('pd_copy')
    if (local_dp_map) then
 
-      !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, ioff, ilyr, m, factor)
+      !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, ioff, ilyr, m, factor)
       do lchnk = begchunk, endchunk
          ncols = get_ncols_p(lchnk)
          call get_gcol_all_p(lchnk, pcols, pgcols)
@@ -515,7 +515,7 @@ subroutine p_d_coupling(phys_state, phys_tend, dyn_in, tl_f, tl_qdp)
       allocate(bbuffer(tsize*block_buf_nrecs))
       allocate(cbuffer(tsize*chunk_buf_nrecs))
 
-      !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, cpter, i, icol, ilyr, m, factor)
+      !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, cpter, i, icol, ilyr, m, factor)
       do lchnk = begchunk, endchunk
          ncols = get_ncols_p(lchnk)
 
@@ -562,7 +562,7 @@ subroutine p_d_coupling(phys_state, phys_tend, dyn_in, tl_f, tl_qdp)
             allocate(bpter(npsq,0:pver))
          end if
 
-         !$omp parallel do num_threads(horz_num_threads) private (ie, bpter, icol, ilyr, m, ncols)
+         !!$omp parallel do num_threads(horz_num_threads) private (ie, bpter, icol, ilyr, m, ncols)
          do ie = 1, nelemd
 
             if (fv_nphys > 0) then
@@ -629,7 +629,7 @@ subroutine p_d_coupling(phys_state, phys_tend, dyn_in, tl_f, tl_qdp)
 
          call t_startf('putUniquePoints')
 
-         !$omp parallel do num_threads(horz_num_threads) private(ie,ncols)
+         !!$omp parallel do num_threads(horz_num_threads) private(ie,ncols)
          do ie = 1, nelemd
             ncols = elem(ie)%idxP%NumUniquePts
             call putUniquePoints(elem(ie)%idxP, nlev, T_tmp(1:ncols,:,ie),       &
@@ -759,7 +759,7 @@ subroutine derived_phys_dry(phys_state, phys_tend, pbuf2d)
 
    ! Evaluate derived quantities
 
-   !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncol, k, i, m , zvirv, pbuf_chnk, factor_array)
+   !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncol, k, i, m , zvirv, pbuf_chnk, factor_array)
    do lchnk = begchunk,endchunk
 
       ncol = get_ncols_p(lchnk)

--- a/components/cam/src/dynamics/se/dycore/bndry_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/bndry_mod.F90
@@ -781,7 +781,7 @@ contains
      kptr=0
      call ghostpack(ghostbuf_cv, cin(:,:,:,ie),nlev,kptr,ie)
   end do
-  call ghost_exchange(hybrid,ghostbuf_cv)
+  call ghost_exchange(hybrid,ghostbuf_cv,location='compute_ghost_corner_orientation')
   do ie=nets,nete
      kptr=0
      call ghostunpack(ghostbuf_cv, cout(:,:,:,ie),nlev,kptr,ie)

--- a/components/cam/src/dynamics/se/dycore/bndry_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/bndry_mod.F90
@@ -152,7 +152,7 @@ contains
           endif
        enddo
     endif
-30  format(a,'Potential performance issue: ',a,'LenMoveptr,nthreads: ',2(i3))
+30  format(a,'Potential perf issue: ',a,'LenMoveptr,nthreads: ',2(i3))
   end subroutine copyBuffer
 
   subroutine bndry_exchange_a2ao(par,nthreads,ithr,buffer,location)
@@ -596,6 +596,12 @@ contains
     character(len=*), optional  :: location
 
     character(len=*), parameter :: subname = 'bndry_exchange_threaded'
+!VERBOSE
+!    if(present(location)) then 
+!       print *,subname,' ',location 
+!    else
+!       print *,subname,' somewhere'
+!    endif
 
     call gbarrier(buffer%gbarrier, hybrid%ithr)
     if(buffer%bndry_type == HME_BNDRY_A2A) then
@@ -762,7 +768,7 @@ contains
   if (hybrid%nthreads > 1) then
      call endrun('ERROR: compute_ghost_corner_orientation must be called before threaded region')
   endif
-  call initghostbuffer(hybrid%par,ghostbuf_cv,elem,nlev,nc,nc)
+  call initghostbuffer(hybrid%par,ghostbuf_cv,elem,nlev,nc,nc,nthreads=1)
 
 
   cin = 0._r8

--- a/components/cam/src/dynamics/se/dycore/comp_ctr_vol_around_gll_pts.F90
+++ b/components/cam/src/dynamics/se/dycore/comp_ctr_vol_around_gll_pts.F90
@@ -560,7 +560,7 @@ call pio_write_darray(file, grid_corner_lon_id, iodesc, gwork, status)
       call edgeVpack(edge1,test,1,0,ie)
     end do
 
-    call bndry_exchange(hybrid, edge1)
+    call bndry_exchange(hybrid, edge1,location='InitControlVolumes_duel')
 
     test = 0
     do ie=nets,nete
@@ -2015,7 +2015,7 @@ call pio_write_darray(file, grid_corner_lon_id, iodesc, gwork, status)
 
     end do  ! loop over NE
 
-    call bndry_exchange(hybrid,edge1)
+    call bndry_exchange(hybrid,edge1,location='construct_cv_gll #1')
 
     do ie=nets,nete
       kptr=0
@@ -2093,7 +2093,7 @@ call pio_write_darray(file, grid_corner_lon_id, iodesc, gwork, status)
       call edgeVpack(edge1,vertpack,3,kptr,ie)
     end do
 
-    call bndry_exchange(hybrid,edge1)
+    call bndry_exchange(hybrid,edge1,location='construct_cv_gll #2')
 
     do ie=nets,nete
       kptr=0

--- a/components/cam/src/dynamics/se/dycore/comp_ctr_vol_around_gll_pts.F90
+++ b/components/cam/src/dynamics/se/dycore/comp_ctr_vol_around_gll_pts.F90
@@ -443,7 +443,7 @@ call pio_write_darray(file, grid_corner_lon_id, iodesc, gwork, status)
       allocate(cvlist(ie)%face_no(nv_max,np,np))
     end do
 
-    call initedgebuffer(par,edge1,elem,3,bndry_type=HME_BNDRY_P2P, nthreads=horz_num_threads)
+    call initedgebuffer(par,edge1,elem,3,bndry_type=HME_BNDRY_P2P, nthreads=1)
     call initGhostBuffer3D(ghost_buf,3,np+1,1)
   end subroutine InitControlVolumesData
 

--- a/components/cam/src/dynamics/se/dycore/edge_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/edge_mod.F90
@@ -474,7 +474,7 @@ contains
              nlen = max_num_threads
           end if
        else
-          nlen = max_num_threads
+          nlen = 1
        end if
     end if
     call gbarrier_init(edge%gbarrier, nlen)
@@ -617,8 +617,8 @@ contains
 
 !$OMP BARRIER
 !$OMP MASTER
-    deallocate(edge%buf)
-    deallocate(edge%receive)
+    if(allocated(edge%buf))         deallocate(edge%buf)
+    if(allocated(edge%receive))     deallocate(edge%receive)
     if(associated(edge%putmap))     deallocate(edge%putmap)
     if(associated(edge%getmap))     deallocate(edge%getmap)
     if(associated(edge%reverse))    deallocate(edge%reverse)

--- a/components/cam/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
+++ b/components/cam/src/dynamics/se/dycore/fvm_consistent_se_cslam.F90
@@ -78,7 +78,7 @@ contains
     call t_stopf('fvm:before_Qnhc')
 
     call t_startf('fvm:ghost_exchange:Qnhc')
-    call ghost_exchange(hybrid,ghostbufQnhc)
+    call ghost_exchange(hybrid,ghostbufQnhc,location='ghostbufQnhc')
     call t_stopf('fvm:ghost_exchange:Qnhc')
 
     call t_startf('fvm:orthogonal_swept_areas')
@@ -91,7 +91,7 @@ contains
       end do
       call ghostpack(ghostBufFlux, fvm(ie)%se_flux(:,:,:,:),4*nlev,0,ie)
     end do
-    call ghost_exchange(hybrid,ghostBufFlux)
+    call ghost_exchange(hybrid,ghostBufFlux,location='ghostBufFlux')
     do ie=nets,nete
       call ghostunpack(ghostBufFlux, fvm(ie)%se_flux(:,:,:,:),4*nlev,0,ie)
       do k=1,nlev

--- a/components/cam/src/dynamics/se/dycore/fvm_mapping.F90
+++ b/components/cam/src/dynamics/se/dycore/fvm_mapping.F90
@@ -220,7 +220,7 @@ contains
        call ghostpack(ghostBufQnhc, fld_fvm(:,:,:,:,ie),numlev*num_flds,0,ie)
     end do
 !    call ghost_exchange(hybrid,cellghostbuf)
-    call ghost_exchange(hybrid,ghostbufQnhc)
+    call ghost_exchange(hybrid,ghostbufQnhc,location='fvm2dyn')
     do ie=nets,nete
 !       call ghostunpack(cellghostbuf, fld_fvm(:,:,:,:,ie),numlev*num_flds,0,ie)
        call ghostunpack(ghostbufQnhc, fld_fvm(:,:,:,:,ie),numlev*num_flds,0,ie)
@@ -268,7 +268,7 @@ contains
     do ie=nets,nete
        call ghostpack(cellghostbuf, fld_phys(:,:,:,:,ie),num_lev*num_flds,0,ie)
     end do
-    call ghost_exchange(hybrid,cellghostbuf)
+    call ghost_exchange(hybrid,cellghostbuf,location='fill_halo_phys')
     do ie=nets,nete
        call ghostunpack(cellghostbuf, fld_phys(:,:,:,:,ie),num_lev*num_flds,0,ie)
     end do

--- a/components/cam/src/dynamics/se/dycore/fvm_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/fvm_mod.F90
@@ -13,6 +13,7 @@ module fvm_mod
   use edge_mod,               only: initghostbuffer, freeghostbuffer, ghostpack, ghostunpack
   use edgetype_mod,           only: edgebuffer_t
   use bndry_mod,              only: ghost_exchange
+  use thread_mod,             only: horz_num_threads
 
   use element_mod,            only: element_t
   use fvm_control_volume_mod, only: fvm_struct
@@ -416,9 +417,9 @@ subroutine fill_halo_fvm_prealloc(cellghostbuf,elem,fvm,hybrid,nets,nete,ndepth,
     enddo
     ! Need to allocate ghostBufQnhc after compute_ghost_corner_orientation because it 
     ! changes the values for reverse
-    call initghostbuffer(hybrid%par,ghostBufQnhc,elem,nlev*(ntrac+1),nhc,nc)
-    call initghostbuffer(hybrid%par,ghostBufQ1,elem,nlev*(ntrac+1),1,nc)
-    call initghostbuffer(hybrid%par,ghostBufFlux,elem,4*nlev,nhe,nc)
+    call initghostbuffer(hybrid%par,ghostBufQnhc,elem,nlev*(ntrac+1),nhc,nc,nthreads=horz_num_threads)
+    call initghostbuffer(hybrid%par,ghostBufQ1,elem,nlev*(ntrac+1),1,nc,nthreads=horz_num_threads)
+    call initghostbuffer(hybrid%par,ghostBufFlux,elem,4*nlev,nhe,nc,nthreads=horz_num_threads)
 
   end subroutine fvm_init2
 

--- a/components/cam/src/dynamics/se/dycore/fvm_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/fvm_mod.F90
@@ -63,7 +63,7 @@ contains
     end do
     call t_stopf('FVM:pack')
     call t_startf('FVM:Communication')
-    call ghost_exchange(hybrid,cellghostbuf)
+    call ghost_exchange(hybrid,cellghostbuf,location='fill_halo_fvm_noprealloc')
     call t_stopf('FVM:Communication')
     !-----------------------------------------------------------------------------------!                        
     call t_startf('FVM:Unpack')
@@ -103,7 +103,7 @@ subroutine fill_halo_fvm_prealloc(cellghostbuf,elem,fvm,hybrid,nets,nete,ndepth,
     end do
     call t_stopf('FVM:pack')
     call t_startf('FVM:Communication')
-    call ghost_exchange(hybrid,cellghostbuf)
+    call ghost_exchange(hybrid,cellghostbuf,location='fill_halo_fvm_prealloc')
     call t_stopf('FVM:Communication')
     !-----------------------------------------------------------------------------------!                        
     call t_startf('FVM:Unpack')
@@ -173,7 +173,7 @@ subroutine fill_halo_fvm_prealloc(cellghostbuf,elem,fvm,hybrid,nets,nete,ndepth,
       do ie=nets,nete
         call ghostpack(cellghostbuf, fld(:,:,:,:,ie),numlev*num_flds,0,ie)
       end do
-      call ghost_exchange(hybrid,cellghostbuf)
+      call ghost_exchange(hybrid,cellghostbuf,location='fill_halo_and_extend_panel')
       do ie=nets,nete
         call ghostunpack(cellghostbuf, fld(:,:,:,:,ie),numlev*num_flds,0,ie)
       end do
@@ -479,7 +479,7 @@ subroutine fill_halo_fvm_prealloc(cellghostbuf,elem,fvm,hybrid,nets,nete,ndepth,
         call ghostpack(cellghostbuf, fvm(ie)%spherecentroid(ixy,:,:) ,1,istart,ie)
       end do
     end do
-    call ghost_exchange(hybrid,cellghostbuf)
+    call ghost_exchange(hybrid,cellghostbuf,location='fvm_init3')
     do ie=nets,nete
       istart = 0
       call ghostunpack(cellghostbuf, fvm(ie)%norm_elem_coord(1,:,:),1,istart,ie)
@@ -697,7 +697,7 @@ subroutine fill_halo_fvm_prealloc(cellghostbuf,elem,fvm,hybrid,nets,nete,ndepth,
           call ghostpack(cellghostbuf, fvm(ie)%spherecentroid_physgrid(ixy,:,:) ,1,istart,ie)
         end do
       end do
-      call ghost_exchange(hybrid,cellghostbuf)
+      call ghost_exchange(hybrid,cellghostbuf,location='fvm_pg_init')
       do ie=nets,nete
         istart = 0
         call ghostunpack(cellghostbuf, fvm(ie)%norm_elem_coord_physgrid(1,:,:),1,istart,ie)

--- a/components/cam/src/dynamics/se/dycore/global_norms_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/global_norms_mod.F90
@@ -508,7 +508,7 @@ contains
             zeta(:,:,ie) = elem(ie)%variable_hyperviscosity(:,:)*elem(ie)%spheremp(:,:)
             call edgeVpack(edgebuf,zeta(1,1,ie),1,0,ie)
         end do
-        call bndry_exchange(hybrid,edgebuf)
+        call bndry_exchange(hybrid,edgebuf,location='print_cfl #1')
         do ie=nets,nete
             call edgeVunpack(edgebuf,zeta(1,1,ie),1,0,ie)
             elem(ie)%variable_hyperviscosity(:,:) = zeta(:,:,ie)*elem(ie)%rspheremp(:,:)
@@ -562,7 +562,7 @@ contains
       call edgeVpack(edgebuf,zeta(1,1,ie),1,0,ie)
     end do
 
-    call bndry_exchange(hybrid,edgebuf)
+    call bndry_exchange(hybrid,edgebuf,location='print_cfl #2')
     do ie=nets,nete
       call edgeVunpack(edgebuf,zeta(1,1,ie),1,0,ie)
           elem(ie)%tensorVisc(:,:,rowind,colind) = zeta(:,:,ie)*elem(ie)%rspheremp(:,:)

--- a/components/cam/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -109,9 +109,7 @@ contains
     !                 (K&G 2nd order method has CFL=4. tiny CFL improvement not worth 2nd order)
     !
 
-#ifdef _OPENMP
     call omp_set_nested(.true.)
-#endif
 
     ! default weights for computing mean dynamics fluxes
     eta_ave_w = 1_r8/qsplit
@@ -297,9 +295,7 @@ contains
     end do
     tevolve=tevolve+dt
 
-#ifdef _OPENMP
     call omp_set_nested(.false.)
-#endif
 
     call t_stopf('prim_advance_exp')
   end subroutine prim_advance_exp

--- a/components/cam/src/dynamics/se/dycore/prim_advance_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/prim_advance_mod.F90
@@ -1208,7 +1208,7 @@ contains
      ! Insert communications here: for shared memory, just a single
      ! sync is required
      ! =============================================================
-     call bndry_exchange(hybrid,edge3p1)
+     call bndry_exchange(hybrid,edge3p1,location='edge3p1')
      do ie=nets,nete
        ! ===========================================================
        ! Unpack the edges for vgrad_T and v tendencies...
@@ -1709,7 +1709,7 @@ contains
        kptr=0
        call edgeVpack(edgeOmega, elem(ie)%derived%omega(:,:,:),nlev,kptr, ie)
      end do
-     call bndry_exchange(hybrid,edgeOmega)
+     call bndry_exchange(hybrid,edgeOmega,location='compute_omega #1')
      do ie=nets,nete
        kptr=0
        call edgeVunpack(edgeOmega, elem(ie)%derived%omega(:,:,:),nlev,kptr, ie)
@@ -1732,7 +1732,7 @@ contains
            kptr=0
            call edgeVpack(edgeOmega,Otens(:,:,:,ie) ,nlev,kptr, ie)
          end do
-         call bndry_exchange(hybrid,edgeOmega)
+         call bndry_exchange(hybrid,edgeOmega,location='compute_omega #2')
          do ie=nets,nete
            kptr=0
            call edgeVunpack(edgeOmega, Otens(:,:,:,ie),nlev,kptr, ie)
@@ -1865,7 +1865,7 @@ contains
       call edgeVpack(edge3,Phis_avg (:,:,ie),1   ,kptr,ie)
     end do ! ie=nets,nete
 
-    call bndry_exchange(hybrid,edge3)
+    call bndry_exchange(hybrid,edge3,location='calc_dp3d_reference')
 
     do ie=nets,nete
       kptr = 0

--- a/components/cam/src/dynamics/se/dycore/prim_advection_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/prim_advection_mod.F90
@@ -693,7 +693,7 @@ contains
     end if
   enddo
 
-  call bndry_exchange( hybrid , edgeAdvp1)
+  call bndry_exchange( hybrid , edgeAdvp1,location='edgeAdvp1')
 
   do ie = nets, nete
     ! only perform this operation on thread which owns the first tracer
@@ -906,7 +906,7 @@ contains
       enddo
     enddo
 
-    call bndry_exchange( hybrid , edgeAdv)
+    call bndry_exchange( hybrid , edgeAdv,location='advance_hypervis_scalar')
 
     do ie = nets, nete
       do q = qbeg, qend

--- a/components/cam/src/dynamics/se/dycore/prim_driver_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/prim_driver_mod.F90
@@ -462,10 +462,10 @@ contains
       call t_startf('prim_advec_tracers_remap')
       region_num_threads = tracer_num_threads
       call omp_set_nested(.true.)
-!JMD      !$OMP PARALLEL NUM_THREADS(region_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew)
-!JMD     hybridnew = config_thread_region(hybrid,'tracer')
-      call Prim_Advec_Tracers_remap(elem, deriv,hvcoord,hybrid,dt_q,tl,nets,nete)
-!JMD      !$OMP END PARALLEL
+      !$OMP PARALLEL NUM_THREADS(region_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew)
+      hybridnew = config_thread_region(hybrid,'tracer')
+      call Prim_Advec_Tracers_remap(elem, deriv,hvcoord,hybridnew,dt_q,tl,nets,nete)
+      !$OMP END PARALLEL
       call omp_set_nested(.false.)
       call t_stopf('prim_advec_tracers_remap')
     end if

--- a/components/cam/src/dynamics/se/dycore/prim_driver_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/prim_driver_mod.F90
@@ -461,16 +461,12 @@ contains
 
       call t_startf('prim_advec_tracers_remap')
       region_num_threads = tracer_num_threads
-#ifdef _OPENMP
       call omp_set_nested(.true.)
-#endif
 !JMD      !$OMP PARALLEL NUM_THREADS(region_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew)
 !JMD     hybridnew = config_thread_region(hybrid,'tracer')
       call Prim_Advec_Tracers_remap(elem, deriv,hvcoord,hybrid,dt_q,tl,nets,nete)
 !JMD      !$OMP END PARALLEL
-#ifdef _OPENMP
       call omp_set_nested(.false.)
-#endif
       call t_stopf('prim_advec_tracers_remap')
     end if
     !

--- a/components/cam/src/dynamics/se/dycore/thread_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/thread_mod.F90
@@ -6,7 +6,8 @@ module thread_mod
        omp_set_num_threads, &
        omp_get_max_threads, &
        omp_get_num_threads, &
-       omp_get_nested
+       omp_get_nested,      &
+       omp_set_nested
 #endif
   use cam_logfile,            only: iulog
   use spmd_utils,             only: masterproc
@@ -23,6 +24,7 @@ module thread_mod
   public :: omp_get_max_threads
   public :: omp_get_num_threads
   public :: omp_get_nested
+  public :: omp_set_nested
   public :: initomp
 contains
 
@@ -55,6 +57,10 @@ contains
     omp_get_nested=0
   end function omp_get_nested
 
+  subroutine omp_set_nested(flag)
+    logical :: flag
+  end subroutine omp_set_nested
+
   subroutine initomp
     max_num_threads = 1
     if (masterproc) then
@@ -64,7 +70,9 @@ contains
 
 #else
   subroutine initomp
+    !$OMP PARALLEL
     max_num_threads = omp_get_num_threads()
+    !$OMP END PARALLEL
     if (masterproc) then
       write(iulog,*) "INITOMP: INFO: number of OpenMP threads = ", max_num_threads
     end if

--- a/components/cam/src/dynamics/se/dycore/viscosity_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/viscosity_mod.F90
@@ -669,7 +669,7 @@ subroutine neighbor_minmax(hybrid,edgeMinMax,nets,nete,min_neigh,max_neigh)
       enddo
    enddo
    
-   call bndry_exchange(hybrid,edgeMinMax)
+   call bndry_exchange(hybrid,edgeMinMax,location='neighbor_minmax')
 
    do ie=nets,nete
       do q=qbeg,qend
@@ -713,7 +713,7 @@ subroutine neighbor_minmax_start(hybrid,edgeMinMax,nets,nete,min_neigh,max_neigh
       enddo
    enddo
 
-   call bndry_exchange_start(hybrid,edgeMinMax)
+   call bndry_exchange_start(hybrid,edgeMinMax,location='neighbor_minmax_start')
 
 end subroutine neighbor_minmax_start
 
@@ -733,7 +733,7 @@ subroutine neighbor_minmax_finish(hybrid,edgeMinMax,nets,nete,min_neigh,max_neig
    kblk = kend - kbeg + 1   ! calculate size of the block of vertical levels
    qblk = qend - qbeg + 1   ! calculate size of the block of tracers
 
-   call bndry_exchange_finish(hybrid,edgeMinMax)
+   call bndry_exchange_finish(hybrid,edgeMinMax,location='neighbor_minmax_finish')
 
    do ie=nets,nete
       do q=qbeg, qend

--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -389,8 +389,8 @@ subroutine dyn_readnl(NLFileName)
    ! Set threading numbers to reasonable values
    if ((se_horz_num_threads == 0) .and. (se_vert_num_threads == 0) .and. (se_tracer_num_threads == 0)) then
       ! The user has not set any threading values, choose defaults
-      se_horz_num_threads = max_num_threads
-      se_vert_num_threads = 1
+      se_horz_num_threads = 1
+      se_vert_num_threads = max_num_threads
       se_tracer_num_threads = se_vert_num_threads
    end if
    if (se_horz_num_threads < 1) then
@@ -700,11 +700,12 @@ subroutine dyn_init(dyn_in, dyn_out)
        end if
       end do
 
-!$OMP PARALLEL NUM_THREADS(horz_num_threads), DEFAULT(SHARED), PRIVATE(hybrid,nets,nete,ie)
-      hybrid = config_thread_region(par,'horizontal')
+!!$OMP PARALLEL NUM_THREADS(horz_num_threads), DEFAULT(SHARED), PRIVATE(hybrid,nets,nete,ie)
+      !hybrid = config_thread_region(par,'horizontal')
+      hybrid = config_thread_region(par,'serial')
       call get_loop_ranges(hybrid, ibeg=nets, iend=nete)
       call prim_init2(elem, fvm, hybrid, nets, nete, TimeLevel, hvcoord)
-!$OMP END PARALLEL
+!!$OMP END PARALLEL
 
       if (use_gw_front .or. use_gw_front_igw) call gws_init(elem)
    end if  ! iam < par%nprocs
@@ -2073,8 +2074,9 @@ subroutine map_phis_from_physgrid_to_gll(fvm,elem,phis_phys_tmp,phis_tmp,pmask)
    logical                          :: llimiter(1)
    !----------------------------------------------------------------------------
 
-!$OMP PARALLEL NUM_THREADS(horz_num_threads), DEFAULT(SHARED), PRIVATE(hybrid,nets,nete,ie)
-   hybrid = config_thread_region(par,'horizontal')
+   !!$OMP PARALLEL NUM_THREADS(horz_num_threads), DEFAULT(SHARED), PRIVATE(hybrid,nets,nete,ie)
+   !hybrid = config_thread_region(par,'horizontal')
+   hybrid = config_thread_region(par,'serial')
 
    call get_loop_ranges(hybrid, ibeg=nets, iend=nete)
 
@@ -2101,7 +2103,7 @@ subroutine map_phis_from_physgrid_to_gll(fvm,elem,phis_phys_tmp,phis_tmp,pmask)
    end do
    deallocate(fld_phys)
    deallocate(fld_gll)
-!$OMP END PARALLEL
+   !!$OMP END PARALLEL
 end subroutine map_phis_from_physgrid_to_gll
 
 !========================================================================================

--- a/components/cam/src/dynamics/se/dyn_grid.F90
+++ b/components/cam/src/dynamics/se/dyn_grid.F90
@@ -242,7 +242,7 @@ subroutine dyn_grid_init()
       ! ================================================
 
       if (iam < par%nprocs) then
-!$OMP PARALLEL NUM_THREADS(horz_num_threads), DEFAULT(SHARED), PRIVATE(hybrid,nets,nete)
+!!$OMP PARALLEL NUM_THREADS(horz_num_threads), DEFAULT(SHARED), PRIVATE(hybrid,nets,nete)
          hybrid = config_thread_region(par,'serial')
          call get_loop_ranges(hybrid, ibeg=nets, iend=nete)
 
@@ -250,7 +250,7 @@ subroutine dyn_grid_init()
          call fvm_init2(elem, fvm, hybrid, nets, nete)
          call fvm_pg_init(elem, fvm, hybrid, nets, nete, irecons_tracer)
          call fvm_init3(elem, fvm, hybrid, nets, nete, irecons_tracer)
-!$OMP END PARALLEL
+!!$OMP END PARALLEL
       end if
 
    else

--- a/components/cam/src/dynamics/se/gravity_waves_sources.F90
+++ b/components/cam/src/dynamics/se/gravity_waves_sources.F90
@@ -39,7 +39,7 @@ CONTAINS
     type(element_t), pointer :: elem(:)
 
     ! Set up variables similar to dyn_comp and prim_driver_mod initializations
-    call initEdgeBuffer(par, edge3, elem, 3*nlev,nthreads=horz_num_threads)
+    call initEdgeBuffer(par, edge3, elem, 3*nlev,nthreads=1)
 
     psurf_ref = hypi(plev+1)
 
@@ -68,9 +68,9 @@ CONTAINS
 
     ! This does not need to be a thread private data-structure
     call derivinit(deriv)
-    !$OMP PARALLEL NUM_THREADS(horz_num_threads),  DEFAULT(SHARED), PRIVATE(nets,nete,hybrid,ie,ncols,frontgf_thr,frontga_thr)
-    hybrid = config_thread_region(par,'horizontal')
-!JMD    hybrid = config_thread_region(par,'serial')
+    !!$OMP PARALLEL NUM_THREADS(horz_num_threads),  DEFAULT(SHARED), PRIVATE(nets,nete,hybrid,ie,ncols,frontgf_thr,frontga_thr)
+!    hybrid = config_thread_region(par,'horizontal')
+    hybrid = config_thread_region(par,'serial')
     call get_loop_ranges(hybrid,ibeg=nets,iend=nete)
 
     allocate(frontgf_thr(nphys,nphys,nlev,nets:nete))
@@ -90,7 +90,7 @@ CONTAINS
     end if
     deallocate(frontga_thr)
     deallocate(frontgf_thr)
-    !$OMP END PARALLEL
+    !!$OMP END PARALLEL
 
   end subroutine gws_src_fnct
 

--- a/components/cam/src/dynamics/se/interp_mod.F90
+++ b/components/cam/src/dynamics/se/interp_mod.F90
@@ -304,7 +304,7 @@ CONTAINS
     if(decomp_type==phys_decomp) then
       fld_dyn = -999_R8
       if(local_dp_map) then
-        !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, ioff,k)
+        !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, ioff,k)
         do lchnk=begchunk,endchunk
           ncols=get_ncols_p(lchnk)
           call get_gcol_all_p(lchnk,pcols,pgcols)
@@ -322,7 +322,7 @@ CONTAINS
         allocate( bbuffer(block_buf_nrecs*numlev) )!xxx Steve: this is different that dp_coupling? (no numlev in dp_coupling)
         allocate( cbuffer(chunk_buf_nrecs*numlev) )
 
-        !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, cpter, i, k, icol)
+        !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, cpter, i, k, icol)
         do lchnk = begchunk,endchunk
           ncols = get_ncols_p(lchnk)
 
@@ -347,7 +347,7 @@ CONTAINS
           else
              allocate(bpter(npsq,0:pver))
           end if
-          !$omp parallel do num_threads(horz_num_threads) private (ie, bpter, k, ncols, icol)
+          !!$omp parallel do num_threads(horz_num_threads) private (ie, bpter, k, ncols, icol)
           do ie=1,nelemd
             if (fv_nphys>0) then
               call chunk_to_block_recv_pters(elem(ie)%GlobalID,fv_nphys*fv_nphys,pverp,1,bpter)
@@ -412,9 +412,9 @@ CONTAINS
     !
     ! WARNING - 1:nelemd and nets:nete
     !
-    !$OMP MASTER   !JMD
+    !!$OMP MASTER   !JMD
     dest(:,:,:,1:nelemd) = fld_tmp(1-nhalo:nsize+nhalo,1-nhalo:nsize+nhalo,:,1,1:nelemd)
-    !$OMP END MASTER
+    !!$OMP END MASTER
     deallocate(fld_tmp)
     !
     !***************************************************************************
@@ -564,7 +564,7 @@ CONTAINS
     fld_dyn = -999_R8
     if(decomp_type==phys_decomp) then
       if(local_dp_map) then
-        !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, k, ioff)
+        !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, pgcols, icol, idmb1, idmb2, idmb3, ie, k, ioff)
         do lchnk=begchunk,endchunk
           ncols=get_ncols_p(lchnk)
           call get_gcol_all_p(lchnk,pcols,pgcols)
@@ -582,7 +582,7 @@ CONTAINS
       else
         allocate( bbuffer(2*block_buf_nrecs*numlev) )
         allocate( cbuffer(2*chunk_buf_nrecs*numlev) )
-        !$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, cpter, i, k, icol)
+        !!$omp parallel do num_threads(horz_num_threads) private (lchnk, ncols, cpter, i, k, icol)
         do lchnk = begchunk,endchunk
           ncols = get_ncols_p(lchnk)
 
@@ -607,7 +607,7 @@ CONTAINS
           else
             allocate(bpter(npsq,0:pver))
           end if
-          !$omp parallel do num_threads(horz_num_threads) private (ie, bpter, k, icol)
+          !!$omp parallel do num_threads(horz_num_threads) private (ie, bpter, k, icol)
           do ie=1,nelemd
             if (fv_nphys>0) then
               call chunk_to_block_recv_pters(elem(ie)%GlobalID,fv_nphys*fv_nphys,pverp,2,bpter)
@@ -697,9 +697,9 @@ CONTAINS
     !
     ! WARNING - 1:nelemd and nets:nete
     !
-    !$OMP MASTER   !JMD
+    !!$OMP MASTER   !JMD
     dest(:,:,:,:,1:nelemd) = fld_tmp(1-nhalo:nsize+nhalo,1-nhalo:nsize+nhalo,:,:,1:nelemd)
-    !$OMP END MASTER
+    !!$OMP END MASTER
     deallocate(fld_tmp)
     !
     !***************************************************************************


### PR DESCRIPTION
This set of changes address several of the OpenMP issues that are currently present in the trunk.  In particular it address issues #12, and #14.  While there are still several OpenMP issues that remain in the code these modifications are sufficient to at least get the horizontal, vertical and tracer modes working in CAM-SE and the vertical and tracer modes working in CAM-SE-CSLAM. The horizontal mode in CAM-SE-CSLAM, as well as nested OpenMP threading is still not functional.  It should also be noted that a number of OpenMP loops were deactivated, and the CSLAM advection does is still not threaded.  Performance is currently not a priority in this version.  This pull request has been tested against the FKESSLER_WACCM configuration, using 225 MPI ranks for CAM-SE and 180 MPI ranks for CAM-SE-CSLAM using either 1 or 2 OpenMP threads.  The *.h0.* and *.h1.* files are identical between between the all MPI and MPI + OpenMP threaded versions.