### PR TITLE
Added support for vertical threading in CSLAM

### DIFF
--- a/components/cam/src/dynamics/se/dp_coupling.F90
+++ b/components/cam/src/dynamics/se/dp_coupling.F90
@@ -653,7 +653,7 @@ subroutine p_d_coupling(phys_state, phys_tend, dyn_in, tl_f, tl_qdp)
    ! so do a simple sum (boundary exchange with no weights).
    ! For physics grid, we interpolated into all points, so do weighted average.
 
-   call t_startf('bndry_exchange')
+   call t_startf('p_d_coupling:bndry_exchange')
 
    do ie = 1, nelemd
       if (fv_nphys > 0) then
@@ -712,7 +712,7 @@ subroutine p_d_coupling(phys_state, phys_tend, dyn_in, tl_f, tl_qdp)
          end do
       end if
    end do
-   call t_stopf('bndry_exchange')
+   call t_stopf('p_d_coupling:bndry_exchange')
 
    if (iam < par%nprocs .and. fv_nphys > 0) then
       call test_mapping_output_mapped_tendencies(dyn_in%fvm(1:nelemd), elem(1:nelemd), &

--- a/components/cam/src/dynamics/se/dycore/fvm_mapping.F90
+++ b/components/cam/src/dynamics/se/dycore/fvm_mapping.F90
@@ -253,7 +253,7 @@ contains
 !    use edge_mod      , only: initghostbuffer, freeghostbuffer, ghostpack, ghostunpack
     use edge_mod      , only: ghostpack, ghostunpack
     use edgetype_mod  , only: edgebuffer_t
-    use fvm_mod       , only: ghostBufPG
+    use fvm_mod       , only: ghostBufPG_s
 
     integer              , intent(in)    :: nets,nete,num_lev,num_flds
     real (kind=r8), intent(inout) :: fld_phys(1-nhc_phys:fv_nphys+nhc_phys,1-nhc_phys:fv_nphys+nhc_phys,num_lev,num_flds, &
@@ -275,13 +275,13 @@ contains
 !    call initghostbuffer(hybrid%par,ghotBufPG,elem,num_lev*num_flds,nhc_phys,fv_nphys)
 !    call t_stopf('fvm:fill_halo_phys:initbuffer')
     do ie=nets,nete
-       call ghostpack(ghostBufPG, fld_phys(:,:,:,:,ie),num_lev*num_flds,0,ie)
+       call ghostpack(ghostBufPG_s, fld_phys(:,:,:,:,ie),num_lev*num_flds,0,ie)
     end do
 
-    call ghost_exchange(hybrid,ghostBufPG,location='fill_halo_phys')
+    call ghost_exchange(hybrid,ghostBufPG_s,location='fill_halo_phys')
 
     do ie=nets,nete
-       call ghostunpack(ghostBufPG, fld_phys(:,:,:,:,ie),num_lev*num_flds,0,ie)
+       call ghostunpack(ghostBufPG_s, fld_phys(:,:,:,:,ie),num_lev*num_flds,0,ie)
     end do
     !
     call t_stopf('fvm:fill_halo_phys')

--- a/components/cam/src/dynamics/se/dycore/fvm_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/fvm_mod.F90
@@ -28,8 +28,8 @@ module fvm_mod
   type (EdgeBuffer_t), public  :: ghostBufQnhc_s, ghostBufQnhc_vh, ghostBufQnhc_h
   type (EdgeBuffer_t), public  :: ghostBufQ1_h, ghostBufQ1_vh 
   type (EdgeBuffer_t), public  :: ghostBufFlux_h, ghostBufFlux_vh
-  type (EdgeBuffer_t), public  :: ghostBufQnhcJet, ghostBufFluxJet
-  type (EdgeBuffer_t), public  :: ghostBufPG
+  type (EdgeBuffer_t), public  :: ghostBufQnhcJet_h, ghostBufFluxJet_h
+  type (EdgeBuffer_t), public  :: ghostBufPG_s
 
   interface fill_halo_fvm
      module procedure fill_halo_fvm_noprealloc
@@ -475,9 +475,9 @@ subroutine fill_halo_fvm_prealloc(cellghostbuf,elem,fvm,hybrid,nets,nete,ndepth,
     ! preallocate buffers for physics-dynamics coupling
     !
     if (fv_nphys.ne.nc) then
-       call initghostbuffer(hybrid%par,ghostBufPG,elem,nlev*(4+ntrac),nhc_phys,fv_nphys,nthreads=1)
+       call initghostbuffer(hybrid%par,ghostBufPG_s,elem,nlev*(4+ntrac),nhc_phys,fv_nphys,nthreads=1)
     else
-       call initghostbuffer(hybrid%par,ghostBufPG,elem,nlev*(3+qsize_condensate_loading),nhc_phys,fv_nphys,nthreads=1)
+       call initghostbuffer(hybrid%par,ghostBufPG_s,elem,nlev*(3+qsize_condensate_loading),nhc_phys,fv_nphys,nthreads=1)
     end if
     
     if (fvm_supercycling.ne.fvm_supercycling_jet) then
@@ -485,8 +485,8 @@ subroutine fill_halo_fvm_prealloc(cellghostbuf,elem,fvm,hybrid,nets,nete,ndepth,
       ! buffers for running different fvm time-steps in the jet region
       !
       klev = kmax_jet-kmin_jet+1
-      call initghostbuffer(hybrid%par,ghostBufQnhcJet,elem,klev*(ntrac+1),nhc,nc,nthreads=horz_num_threads)
-      call initghostbuffer(hybrid%par,ghostBufFluxJet,elem,4*klev,nhe,nc,nthreads=horz_num_threads)
+      call initghostbuffer(hybrid%par,ghostBufQnhcJet_h,elem,klev*(ntrac+1),nhc,nc,nthreads=horz_num_threads)
+      call initghostbuffer(hybrid%par,ghostBufFluxJet_h,elem,4*klev,nhe,nc,nthreads=horz_num_threads)
     end if
   end subroutine fvm_init2
 

--- a/components/cam/src/dynamics/se/dycore/prim_driver_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/prim_driver_mod.F90
@@ -333,7 +333,7 @@ contains
     use dimensions_mod,         only: ntrac,fvm_supercycling,fvm_supercycling_jet
     use dimensions_mod,         only: kmin_jet, kmax_jet
     use fvm_mod,                only: ghostBufQnhc_h,ghostBufQnhc_vh,ghostBufQ1_h,ghostBufQ1_vh, ghostBufFlux_h, ghostBufFlux_vh
-    use fvm_mod,                only: ghostBufQnhcJet, ghostBufFluxJet
+    use fvm_mod,                only: ghostBufQnhcJet_h, ghostBufFluxJet_h
 #ifdef waccm_debug
   use cam_history, only: outfld
 #endif  
@@ -471,14 +471,14 @@ contains
       !
       if ((mod(rstep,fvm_supercycling) == 0).and.(mod(rstep,fvm_supercycling_jet) == 0)) then        
 
-        call omp_set_nested(.true.)
-        !$OMP PARALLEL NUM_THREADS(vert_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew2,kbeg,kend)
-        hybridnew2 = config_thread_region(hybrid,'vertical')
-        call get_loop_ranges(hybridnew2,kbeg=kbeg,kend=kend)
-        call Prim_Advec_Tracers_fvm(elem,fvm,hvcoord,hybridnew2,&
-             dt_q,tl,nets,nete,ghostBufQnhc_vh,ghostBufQ1_vh, ghostBufFlux_vh,kbeg,kend)
-        !$OMP END PARALLEL
-        call omp_set_nested(.false.)
+!        call omp_set_nested(.true.)
+!        !$OMP PARALLEL NUM_THREADS(vert_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew2,kbeg,kend)
+!        hybridnew2 = config_thread_region(hybrid,'vertical')
+!        call get_loop_ranges(hybridnew2,kbeg=kbeg,kend=kend)
+        call Prim_Advec_Tracers_fvm(elem,fvm,hvcoord,hybrid,&
+             dt_q,tl,nets,nete,ghostBufQnhc_vh,ghostBufQ1_vh, ghostBufFlux_vh,1,nlev)
+!        !$OMP END PARALLEL
+!        call omp_set_nested(.false.)
         !
         ! to avoid accumulation of truncation error overwrite CSLAM surface pressure with SE
         ! surface pressure
@@ -497,7 +497,7 @@ contains
         ! shorter fvm time-step in jet region
         !
         call Prim_Advec_Tracers_fvm(elem,fvm,hvcoord,hybrid,&
-             dt_q,tl,nets,nete,ghostBufQnhcJet,ghostBufQ1_h, ghostBufFluxJet,kmin_jet,kmax_jet)
+             dt_q,tl,nets,nete,ghostBufQnhcJet_h,ghostBufQ1_h, ghostBufFluxJet_h,kmin_jet,kmax_jet)
       end if
         
 

--- a/components/cam/src/dynamics/se/dycore/prim_driver_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/prim_driver_mod.F90
@@ -329,10 +329,10 @@ contains
     use prim_advance_mod,       only: prim_advance_exp
     use prim_advection_mod,     only: prim_advec_tracers_remap, prim_advec_tracers_fvm, deriv
     use derivative_mod,         only: subcell_integration
-    use hybrid_mod,             only: set_region_num_threads, config_thread_region
+    use hybrid_mod,             only: set_region_num_threads, config_thread_region, get_loop_ranges
     use dimensions_mod,         only: ntrac,fvm_supercycling,fvm_supercycling_jet
     use dimensions_mod,         only: kmin_jet, kmax_jet
-    use fvm_mod,                only: ghostBufQnhc_h,ghostBufQ1_h, ghostBufFlux_h
+    use fvm_mod,                only: ghostBufQnhc_h,ghostBufQnhc_vh,ghostBufQ1_h,ghostBufQ1_vh, ghostBufFlux_h, ghostBufFlux_vh
     use fvm_mod,                only: ghostBufQnhcJet, ghostBufFluxJet
 #ifdef waccm_debug
   use cam_history, only: outfld
@@ -349,17 +349,19 @@ contains
     type (TimeLevel_t), intent(inout) :: tl
     integer, intent(in)               :: rstep ! vertical remap subcycling step
 
-    type (hybrid_t):: hybridnew
+    type (hybrid_t):: hybridnew,hybridnew2
     real(kind=r8)  :: st, st1, dp, dt_q
     integer        :: ie,t,q,k,i,j,n, n_Q
     integer        :: ithr
     integer        :: region_num_threads
+    integer        :: kbeg,kend
 
     real (kind=r8) :: tempdp3d(np,np), x
     real (kind=r8) :: tempmass(nc,nc)
     real (kind=r8) :: tempflux(nc,nc,4)
 
     real (kind=r8) :: dp_np1(np,np)
+
 
     dt_q = dt*qsplit
     ! ===============
@@ -468,8 +470,15 @@ contains
       ! FVM transport
       !
       if ((mod(rstep,fvm_supercycling) == 0).and.(mod(rstep,fvm_supercycling_jet) == 0)) then        
-        call Prim_Advec_Tracers_fvm(elem,fvm,hvcoord,hybrid,&
-             dt_q,tl,nets,nete,ghostBufQnhc_h,ghostBufQ1_h, ghostBufFlux_h,1,nlev)
+
+        call omp_set_nested(.true.)
+        !$OMP PARALLEL NUM_THREADS(vert_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew2,kbeg,kend)
+        hybridnew2 = config_thread_region(hybrid,'vertical')
+        call get_loop_ranges(hybridnew2,kbeg=kbeg,kend=kend)
+        call Prim_Advec_Tracers_fvm(elem,fvm,hvcoord,hybridnew2,&
+             dt_q,tl,nets,nete,ghostBufQnhc_vh,ghostBufQ1_vh, ghostBufFlux_vh,kbeg,kend)
+        !$OMP END PARALLEL
+        call omp_set_nested(.false.)
         !
         ! to avoid accumulation of truncation error overwrite CSLAM surface pressure with SE
         ! surface pressure

--- a/components/cam/src/dynamics/se/dycore/vertremap_mod.F90
+++ b/components/cam/src/dynamics/se/dycore/vertremap_mod.F90
@@ -65,7 +65,7 @@ subroutine remap1(Qdp,nx,qstart,qstop,qsize,dp1,dp2,hybrid)
   logical :: abort=.false.
 
   if (vert_remap_q_alg == 1 .or. vert_remap_q_alg == 2) then
-    call t_startf('remap_Q_ppm')
+    !call t_startf('remap_Q_ppm')
     if ( present(hybrid) ) then
       !$OMP PARALLEL NUM_THREADS(tracer_num_threads), DEFAULT(SHARED), PRIVATE(hybridnew,qbeg,qend)
       hybridnew = config_thread_region(hybrid,'tracer')
@@ -75,7 +75,7 @@ subroutine remap1(Qdp,nx,qstart,qstop,qsize,dp1,dp2,hybrid)
     else
       call remap_Q_ppm(qdp,nx,qstart,qstop,qsize,dp1,dp2)
     endif
-    call t_stopf('remap_Q_ppm')
+    !call t_stopf('remap_Q_ppm')
     return
   endif
 
@@ -526,6 +526,7 @@ subroutine remap_Q_ppm(Qdp,nx,qstart,qstop,qsize,dp1,dp2)
         !Find the index of the old grid cell in which this new cell's bottom interface resides.
         do while ( pio(kk) <= pin(k+1) )
           kk = kk + 1
+          if(kk==nlev+2) exit
         enddo
         kk = kk - 1                   !kk is now the cell index we're integrating over.
         if (kk == nlev+1) kk = nlev   !This is to keep the indices in bounds.

--- a/components/cam/src/dynamics/se/dyn_comp.F90
+++ b/components/cam/src/dynamics/se/dyn_comp.F90
@@ -749,9 +749,6 @@ subroutine dyn_init(dyn_in, dyn_out)
    if (iam < par%nprocs) then
       call prim_advance_init(par,elem)
       !$OMP PARALLEL NUM_THREADS(horz_num_threads), DEFAULT(SHARED), PRIVATE(hybrid,nets,nete)
-      hybrid = config_thread_region(par,'horizontal')!tphl
-!tphl      hybrid = config_thread_region(par,'serial')
-
       hybrid = config_thread_region(par,'horizontal')
       call get_loop_ranges(hybrid, ibeg=nets, iend=nete)
       call prim_init2(elem, fvm, hybrid, nets, nete, TimeLevel, hvcoord)
@@ -863,8 +860,8 @@ subroutine dyn_run(dyn_state)
 
    ldiag = hist_fld_active('ABS_dPSdt')
    if (ldiag) then
-      allocate(ps_before(np,np,nets:nete))
-      allocate(abs_ps_tend(np,np,nets:nete))
+      allocate(ps_before(np,np,nelemd))
+      allocate(abs_ps_tend(np,np,nelemd))
    end if
 
    !$OMP PARALLEL NUM_THREADS(horz_num_threads), DEFAULT(SHARED), PRIVATE(hybrid,nets,nete,n,ie,m,i,j,k)


### PR DESCRIPTION
This update enables vertical threading in CSLAM.  Currently the focus of this work has not been on performance but rather on correctness.  This code has been tested using both 2 and 4 OMP threads using various combinations of horizontal, vertical, and tracer threading.  All of them provide a B4B match to single threaded versions including a nested configuration where each MPI ranks supports 2 threads over the horizontal, and each of those threads supports 2 threads over the vertical.  This PR as well as previous commits address issues #11, #12, #13, and #14.  Note that currently vertical threading is disabled when the Prim_Advec_Tracers_fvm() is called using a reduced number of vertical levels.